### PR TITLE
Load for settings window

### DIFF
--- a/src/main/features/core/desktopSettings.js
+++ b/src/main/features/core/desktopSettings.js
@@ -17,6 +17,7 @@ export const showDesktopSettings = () => {
     autoHideMenuBar: true,
     frame: Settings.get('nativeFrame'),
     titleBarStyle: Settings.get('nativeFrame') && process.platform === 'darwin' ? 'hidden' : 'default',
+    darkTheme: Settings.get('themeType') === 'FULL',
     show: false,
     webPreferences: {
       nodeIntegration: true,
@@ -45,6 +46,7 @@ export const showColorWheel = () => {
     autoHideMenuBar: true,
     frame: Settings.get('nativeFrame'),
     titleBarStyle: Settings.get('nativeFrame') && process.platform === 'darwin' ? 'hidden' : 'default',
+    darkTheme: Settings.get('themeType') === 'FULL',
     show: false,
     webPreferences: {
       nodeIntegration: true,


### PR DESCRIPTION
This should make the settings and color wheel browserWindows the same as the main window's selected theme:

![Screenshot from 2019-06-26 14-46-38](https://user-images.githubusercontent.com/8471701/60206311-3e6a3000-9821-11e9-978f-a00c0ab1a758.png)
